### PR TITLE
FEM-29719 add support in widgetId for anonymous login request

### DIFF
--- a/AdvancedSamples/TestApp/app/src/main/java/com/kaltura/kalturaplayertestapp/PlayerActivity.java
+++ b/AdvancedSamples/TestApp/app/src/main/java/com/kaltura/kalturaplayertestapp/PlayerActivity.java
@@ -327,6 +327,7 @@ public class PlayerActivity extends AppCompatActivity implements Observer {
                 .setKs(appPlayerInitConfig.ks)
                 .setPreload(appPlayerInitConfig.preload)
                 .setReferrer(appPlayerInitConfig.referrer)
+                .setWidgetId(appPlayerInitConfig.widgetId)
                 .setAllowCrossProtocolEnabled(appPlayerInitConfig.allowCrossProtocolEnabled)
                 .setPreferredMediaFormat(appPlayerInitConfig.preferredFormat)
                 .setSecureSurface(appPlayerInitConfig.secureSurface)

--- a/AdvancedSamples/TestApp/app/src/main/java/com/kaltura/kalturaplayertestapp/converters/PlayerConfig.java
+++ b/AdvancedSamples/TestApp/app/src/main/java/com/kaltura/kalturaplayertestapp/converters/PlayerConfig.java
@@ -45,6 +45,7 @@ public class PlayerConfig {
     public ABRSettings abrSettings;
     public RequestConfiguration requestConfiguration;
     public String referrer;
+    public String widgetId;
     public Boolean forceSinglePlayerEngine;
     public List<Media> mediaList;
     public TrackSelection trackSelection;


### PR DESCRIPTION
Example -> widgetId:
{
  "playerType": "ovp",
  "baseUrl": "http:\/\/qa-apache-php7.dev.kaltura.com\/",
  "partnerId": 1091,
  "widgetId": "_1091",
  "autoPlay": true,
  "mediaList": [
    {
      "entryId": "111111"
    }
  ],
  "preferredFormat": "hls",
  "startPosition": 0,
  "companionWidth": 300,
  "companionHeight": 250,
  "imaWebOpener": "self"
}